### PR TITLE
Add new error types, fix error reporting 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .bundle
 .config
 .yardoc
+.byebug_history
+.rakeTasks
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/exponent-server-sdk.gemspec
+++ b/exponent-server-sdk.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'byebug'
 end

--- a/lib/exponent-server-sdk/version.rb
+++ b/lib/exponent-server-sdk/version.rb
@@ -1,3 +1,3 @@
 module Exponent
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.2.0'.freeze
 end


### PR DESCRIPTION
I think this would be a better candidate for a new major or minor release as I've removed the deprecated methods.

Refering to #43 

This library has had very little development it seems in the past year and doesn't support some error reporting at all such as PUSH_TOO_MANY_EXPERIENCE_IDS.

I attempted to leave all the old non-deprecated functionality the same and got all the test cases passing to ensure no regression. Also removed and cleaned up other things in the code.

Here are the things I changed:

1. Added support for PUSH_TOO_MANY_EXPERIENCE_IDS (including tests) and Internal Server Error error so you'll actually see if you are getting that error.
1. Whenever there is an unknown error, I always add the actual error message onto it so you can see what exactly failed in the code. I also pass through the details into the error message so you know what went wrong by the error message.
1. Allow the ability to pass in options for Typheous.post so you don't have to pass in a different HTML client, so for example you can now pass in ssl_verifypeer: false to get the gem working in AWS if you are in that environment.
1. Removed the deprecated methods.

