### PR TITLE
change syntax to support ruby 2.2.10

### DIFF
--- a/lib/exponent-server-sdk.rb
+++ b/lib/exponent-server-sdk.rb
@@ -149,7 +149,7 @@ module Exponent
       private
 
       def sort_results
-        data = body&.fetch('data', nil) || nil
+        data = body.fetch('data', nil) if body || nil
 
         # something is definitely wrong
         return if data.nil?


### PR DESCRIPTION
In this pull request:

- I changed the syntax used in a single line to support using the SDK in a ruby 2.2.10 application